### PR TITLE
Extract MCP utilities into standalone package

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,31 @@
+![n8n.io - Workflow Automation](https://user-images.githubusercontent.com/65276001/173571060-9f2f6d7b-bac0-43b6-bdb2-001da9694058.png)
+
+# n8n-mcp
+
+Utilities for interacting with the Model Context Protocol.
+
+```bash
+npm install @n8n/mcp
+```
+
+## Project setup
+
+```bash
+pnpm install
+```
+
+### Build
+
+```bash
+pnpm build
+```
+
+### Development
+
+```bash
+pnpm dev
+```
+
+## License
+
+You can find the license information [here](https://github.com/n8n-io/n8n/blob/master/README.md#license)

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@n8n/mcp",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "clean": "rimraf dist",
+    "build": "tsup --tsconfig tsconfig.build.json",
+    "dev": "tsup --watch --tsconfig tsconfig.build.json"
+  },
+  "dependencies": {
+    "@langchain/core": "catalog:",
+    "langchain": "catalog:",
+    "@modelcontextprotocol/sdk": "catalog:",
+    "n8n-workflow": "workspace:*",
+    "zod": "catalog:",
+    "zod-to-json-schema": "catalog:",
+    "@n8n/json-schema-to-zod": "workspace:*"
+  },
+  "devDependencies": {
+    "@n8n/typescript-config": "workspace:*",
+    "tsup": "catalog:",
+    "rimraf": "catalog:"
+  }
+}

--- a/mcp/src/FlushingTransport.ts
+++ b/mcp/src/FlushingTransport.ts
@@ -1,0 +1,61 @@
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type { StreamableHTTPServerTransportOptions } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+import type { Response } from 'express';
+import type { IncomingMessage, ServerResponse } from 'http';
+
+export type CompressionResponse = Response & {
+	/**
+	 * `flush()` is defined in the compression middleware.
+	 * This is necessary because the compression middleware sometimes waits
+	 * for a certain amount of data before sending the data to the client
+	 */
+	flush: () => void;
+};
+
+export class FlushingSSEServerTransport extends SSEServerTransport {
+	constructor(
+		_endpoint: string,
+		private response: CompressionResponse,
+	) {
+		super(_endpoint, response);
+	}
+
+	async send(message: JSONRPCMessage): Promise<void> {
+		await super.send(message);
+		this.response.flush();
+	}
+
+	async handleRequest(
+		req: IncomingMessage,
+		resp: ServerResponse,
+		message: IncomingMessage,
+	): Promise<void> {
+		await super.handlePostMessage(req, resp, message);
+		this.response.flush();
+	}
+}
+
+export class FlushingStreamableHTTPTransport extends StreamableHTTPServerTransport {
+	private response: CompressionResponse;
+
+	constructor(options: StreamableHTTPServerTransportOptions, response: CompressionResponse) {
+		super(options);
+		this.response = response;
+	}
+
+	async send(message: JSONRPCMessage): Promise<void> {
+		await super.send(message);
+		this.response.flush();
+	}
+
+	async handleRequest(
+		req: IncomingMessage,
+		resp: ServerResponse,
+		parsedBody?: unknown,
+	): Promise<void> {
+		await super.handleRequest(req, resp, parsedBody);
+		this.response.flush();
+	}
+}

--- a/mcp/src/McpServer.ts
+++ b/mcp/src/McpServer.ts
@@ -1,0 +1,317 @@
+import type { Tool } from '@langchain/core/tools';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+import type {
+	JSONRPCMessage,
+	ServerRequest,
+	ServerNotification,
+} from '@modelcontextprotocol/sdk/types.js';
+import {
+	JSONRPCMessageSchema,
+	ListToolsRequestSchema,
+	CallToolRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { randomUUID } from 'crypto';
+import type * as express from 'express';
+import type { IncomingMessage } from 'http';
+import { jsonParse, OperationalError, type Logger } from 'n8n-workflow';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+import { FlushingSSEServerTransport, FlushingStreamableHTTPTransport } from './FlushingTransport';
+import type { CompressionResponse } from './FlushingTransport';
+
+/**
+ * Parses the JSONRPC message and checks whether the method used was a tool
+ * call. This is necessary in order to not have executions for listing tools
+ * and other commands sent by the MCP client
+ */
+function wasToolCall(body: string) {
+	try {
+		const message: unknown = JSON.parse(body);
+		const parsedMessage: JSONRPCMessage = JSONRPCMessageSchema.parse(message);
+		return (
+			'method' in parsedMessage &&
+			'id' in parsedMessage &&
+			parsedMessage?.method === CallToolRequestSchema.shape.method.value
+		);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Extracts the request ID from a JSONRPC message (for example for tool calls).
+ * Returns undefined if the message doesn't have an ID (for example on a tool list request)
+ *
+ */
+function getRequestId(message: unknown): string | undefined {
+	try {
+		const parsedMessage: JSONRPCMessage = JSONRPCMessageSchema.parse(message);
+		return 'id' in parsedMessage ? String(parsedMessage.id) : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * This singleton is shared across the instance, making sure it is the one
+ * keeping account of MCP servers.
+ * It needs to stay in memory to keep track of the long-lived connections.
+ * It requires a logger at first creation to set everything up.
+ */
+export class McpServerManager {
+	static #instance: McpServerManager;
+
+	servers: { [sessionId: string]: Server } = {};
+
+	transports: {
+		[sessionId: string]: FlushingSSEServerTransport | FlushingStreamableHTTPTransport;
+	} = {};
+
+	private tools: { [sessionId: string]: Tool[] } = {};
+
+	private resolveFunctions: { [callId: string]: CallableFunction } = {};
+
+	logger: Logger;
+
+	private constructor(logger: Logger) {
+		this.logger = logger;
+		this.logger.debug('MCP Server created');
+	}
+
+	static instance(logger: Logger): McpServerManager {
+		if (!McpServerManager.#instance) {
+			McpServerManager.#instance = new McpServerManager(logger);
+			logger.debug('Created singleton MCP manager');
+		}
+
+		return McpServerManager.#instance;
+	}
+
+	async createServerWithSSETransport(
+		serverName: string,
+		postUrl: string,
+		resp: CompressionResponse,
+	): Promise<void> {
+		const server = new Server(
+			{
+				name: serverName,
+				version: '0.1.0',
+			},
+			{
+				capabilities: {
+					tools: {},
+				},
+			},
+		);
+
+		const transport = new FlushingSSEServerTransport(postUrl, resp);
+
+		this.setUpHandlers(server);
+
+		const sessionId = transport.sessionId;
+		this.transports[sessionId] = transport;
+		this.servers[sessionId] = server;
+
+		resp.on('close', async () => {
+			this.logger.debug(`Deleting transport for ${sessionId}`);
+			delete this.tools[sessionId];
+			delete this.transports[sessionId];
+			delete this.servers[sessionId];
+		});
+		await server.connect(transport);
+
+		// Make sure we flush the compression middleware, so that it's not waiting for more content to be added to the buffer
+		if (resp.flush) {
+			resp.flush();
+		}
+	}
+
+	getSessionId(req: express.Request): string | undefined {
+		// Session ID can be passed either as a query parameter (SSE transport)
+		// or in the header (StreamableHTTP transport).
+		return (req.query.sessionId ?? req.headers['mcp-session-id']) as string | undefined;
+	}
+
+	getTransport(
+		sessionId: string,
+	): FlushingSSEServerTransport | FlushingStreamableHTTPTransport | undefined {
+		return this.transports[sessionId];
+	}
+
+	async createServerWithStreamableHTTPTransport(
+		serverName: string,
+		resp: CompressionResponse,
+		req?: express.Request,
+	): Promise<void> {
+		const server = new Server(
+			{
+				name: serverName,
+				version: '0.1.0',
+			},
+			{
+				capabilities: {
+					tools: {},
+				},
+			},
+		);
+
+		const transport = new FlushingStreamableHTTPTransport(
+			{
+				sessionIdGenerator: () => randomUUID(),
+				onsessioninitialized: (sessionId) => {
+					this.logger.debug(`New session initialized: ${sessionId}`);
+					transport.onclose = () => {
+						this.logger.debug(`Deleting transport for ${sessionId}`);
+						delete this.tools[sessionId];
+						delete this.transports[sessionId];
+						delete this.servers[sessionId];
+					};
+					this.transports[sessionId] = transport;
+					this.servers[sessionId] = server;
+				},
+			},
+			resp,
+		);
+
+		this.setUpHandlers(server);
+
+		await server.connect(transport);
+
+		await transport.handleRequest(req as IncomingMessage, resp, req?.body);
+		if (resp.flush) {
+			resp.flush();
+		}
+	}
+
+	async handlePostMessage(req: express.Request, resp: CompressionResponse, connectedTools: Tool[]) {
+		// Session ID can be passed either as a query parameter (SSE transport)
+		// or in the header (StreamableHTTP transport).
+		const sessionId = this.getSessionId(req);
+		const transport = this.getTransport(sessionId as string);
+		if (sessionId && transport) {
+			// We need to add a promise here because the `handlePostMessage` will send something to the
+			// MCP Server, that will run in a different context. This means that the return will happen
+			// almost immediately, and will lead to marking the sub-node as "running" in the final execution
+			const message = jsonParse(req.rawBody.toString());
+			const messageId = getRequestId(message);
+			// Use session & message ID if available, otherwise fall back to sessionId
+			const callId = messageId ? `${sessionId}_${messageId}` : sessionId;
+			this.tools[sessionId] = connectedTools;
+
+			try {
+				await new Promise(async (resolve) => {
+					this.resolveFunctions[callId] = resolve;
+					await transport.handleRequest(req, resp, message as IncomingMessage);
+				});
+			} finally {
+				delete this.resolveFunctions[callId];
+			}
+		} else {
+			this.logger.warn(`No transport found for session ${sessionId}`);
+			resp.status(401).send('No transport found for sessionId');
+		}
+
+		if (resp.flush) {
+			resp.flush();
+		}
+
+		return wasToolCall(req.rawBody.toString());
+	}
+
+	async handleDeleteRequest(req: express.Request, resp: CompressionResponse) {
+		const sessionId = this.getSessionId(req);
+
+		if (!sessionId) {
+			resp.status(400).send('No sessionId provided');
+			return;
+		}
+
+		const transport = this.getTransport(sessionId);
+
+		if (transport) {
+			if (transport instanceof FlushingStreamableHTTPTransport) {
+				await transport.handleRequest(req, resp);
+				return;
+			} else {
+				// For SSE transport, we don't support DELETE requests
+				resp.status(405).send('Method Not Allowed');
+				return;
+			}
+		}
+
+		resp.status(404).send('Session not found');
+	}
+
+	setUpHandlers(server: Server) {
+		server.setRequestHandler(
+			ListToolsRequestSchema,
+			async (_, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => {
+				if (!extra.sessionId) {
+					throw new OperationalError('Require a sessionId for the listing of tools');
+				}
+
+				return {
+					tools: this.tools[extra.sessionId].map((tool) => {
+						return {
+							name: tool.name,
+							description: tool.description,
+							// Allow additional properties on tool call input
+							inputSchema: zodToJsonSchema(tool.schema, { removeAdditionalStrategy: 'strict' }),
+						};
+					}),
+				};
+			},
+		);
+
+		server.setRequestHandler(
+			CallToolRequestSchema,
+			async (request, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => {
+				if (!request.params?.name || !request.params?.arguments) {
+					throw new OperationalError('Require a name and arguments for the tool call');
+				}
+				if (!extra.sessionId) {
+					throw new OperationalError('Require a sessionId for the tool call');
+				}
+
+				const callId = extra.requestId ? `${extra.sessionId}_${extra.requestId}` : extra.sessionId;
+
+				const requestedTool: Tool | undefined = this.tools[extra.sessionId].find(
+					(tool) => tool.name === request.params.name,
+				);
+				if (!requestedTool) {
+					throw new OperationalError('Tool not found');
+				}
+
+				try {
+					const result = await requestedTool.invoke(request.params.arguments);
+					if (this.resolveFunctions[callId]) {
+						this.resolveFunctions[callId]();
+					} else {
+						this.logger.warn(`No resolve function found for ${callId}`);
+					}
+
+					this.logger.debug(`Got request for ${requestedTool.name}, and executed it.`);
+
+					if (typeof result === 'object') {
+						return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+					}
+					if (typeof result === 'string') {
+						return { content: [{ type: 'text', text: result }] };
+					}
+					return { content: [{ type: 'text', text: String(result) }] };
+				} catch (error) {
+					this.logger.error(`Error while executing Tool ${requestedTool.name}: ${error}`);
+					return { isError: true, content: [{ type: 'text', text: `Error: ${error.message}` }] };
+				}
+			},
+		);
+
+		server.onclose = () => {
+			this.logger.debug('Closing MCP Server');
+		};
+		server.onerror = (error: unknown) => {
+			this.logger.error(`MCP Error: ${error}`);
+		};
+	}
+}

--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -1,0 +1,218 @@
+import { DynamicStructuredTool, type DynamicStructuredToolInput } from '@langchain/core/tools';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import { CompatibilityCallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
+import { Toolkit } from 'langchain/agents';
+import {
+	createResultError,
+	createResultOk,
+	type IDataObject,
+	type IExecuteFunctions,
+	type Result,
+} from 'n8n-workflow';
+import { z } from 'zod';
+
+import { jsonSchemaToZod } from '@n8n/json-schema-to-zod';
+
+import type { McpAuthenticationOption, McpTool, McpToolIncludeMode } from './types';
+
+export async function getAllTools(client: Client, cursor?: string): Promise<McpTool[]> {
+	const { tools, nextCursor } = await client.listTools({ cursor });
+
+	if (nextCursor) {
+		return (tools as McpTool[]).concat(await getAllTools(client, nextCursor));
+	}
+
+	return tools as McpTool[];
+}
+
+export function getSelectedTools({
+	mode,
+	includeTools,
+	excludeTools,
+	tools,
+}: {
+	mode: McpToolIncludeMode;
+	includeTools?: string[];
+	excludeTools?: string[];
+	tools: McpTool[];
+}) {
+	switch (mode) {
+		case 'selected': {
+			if (!includeTools?.length) return tools;
+			const include = new Set(includeTools);
+			return tools.filter((tool) => include.has(tool.name));
+		}
+		case 'except': {
+			const except = new Set(excludeTools ?? []);
+			return tools.filter((tool) => !except.has(tool.name));
+		}
+		case 'all':
+		default:
+			return tools;
+	}
+}
+
+export const getErrorDescriptionFromToolCall = (result: unknown): string | undefined => {
+	if (result && typeof result === 'object') {
+		if ('content' in result && Array.isArray(result.content)) {
+			const errorMessage = (result.content as Array<{ type: 'text'; text: string }>).find(
+				(content) => content && typeof content === 'object' && typeof content.text === 'string',
+			)?.text;
+			return errorMessage;
+		} else if ('toolResult' in result && typeof result.toolResult === 'string') {
+			return result.toolResult;
+		}
+		if ('message' in result && typeof result.message === 'string') {
+			return result.message;
+		}
+	}
+
+	return undefined;
+};
+
+export const createCallTool =
+	(name: string, client: Client, onError: (error: string | undefined) => void) =>
+	async (args: IDataObject) => {
+		let result: Awaited<ReturnType<Client['callTool']>>;
+		try {
+			result = await client.callTool({ name, arguments: args }, CompatibilityCallToolResultSchema);
+		} catch (error) {
+			return onError(getErrorDescriptionFromToolCall(error));
+		}
+
+		if (result.isError) {
+			return onError(getErrorDescriptionFromToolCall(result));
+		}
+
+		if (result.toolResult !== undefined) {
+			return result.toolResult;
+		}
+
+		if (result.content !== undefined) {
+			return result.content;
+		}
+
+		return result;
+	};
+
+export function mcpToolToDynamicTool(
+	tool: McpTool,
+	onCallTool: DynamicStructuredToolInput['func'],
+): DynamicStructuredTool<z.ZodObject<any, any, any, any>> {
+       const rawSchema = jsonSchemaToZod(tool.inputSchema);
+
+	// Ensure we always have an object schema for structured tools
+	const objectSchema =
+		rawSchema instanceof z.ZodObject ? rawSchema : z.object({ value: rawSchema });
+
+	return new DynamicStructuredTool({
+		name: tool.name,
+		description: tool.description ?? '',
+		schema: objectSchema,
+		func: onCallTool,
+		metadata: { isFromToolkit: true },
+	});
+}
+
+export class McpToolkit extends Toolkit {
+	constructor(public tools: Array<DynamicStructuredTool<z.ZodObject<any, any, any, any>>>) {
+		super();
+	}
+}
+
+function safeCreateUrl(url: string, baseUrl?: string | URL): Result<URL, Error> {
+	try {
+		return createResultOk(new URL(url, baseUrl));
+	} catch (error) {
+		return createResultError(error);
+	}
+}
+
+function normalizeAndValidateUrl(input: string): Result<URL, Error> {
+	const withProtocol = !/^https?:\/\//i.test(input) ? `https://${input}` : input;
+	const parsedUrl = safeCreateUrl(withProtocol);
+
+	if (!parsedUrl.ok) {
+		return createResultError(parsedUrl.error);
+	}
+
+	return parsedUrl;
+}
+
+type ConnectMcpClientError =
+	| { type: 'invalid_url'; error: Error }
+	| { type: 'connection'; error: Error };
+export async function connectMcpClient({
+	headers,
+	sseEndpoint,
+	name,
+	version,
+}: {
+	sseEndpoint: string;
+	headers?: Record<string, string>;
+	name: string;
+	version: number;
+}): Promise<Result<Client, ConnectMcpClientError>> {
+	try {
+		const endpoint = normalizeAndValidateUrl(sseEndpoint);
+
+		if (!endpoint.ok) {
+			return createResultError({ type: 'invalid_url', error: endpoint.error });
+		}
+
+		const transport = new SSEClientTransport(endpoint.result, {
+			eventSourceInit: {
+				fetch: async (url, init) =>
+					await fetch(url, {
+						...init,
+						headers: {
+							...headers,
+							Accept: 'text/event-stream',
+						},
+					}),
+			},
+			requestInit: { headers },
+		});
+
+		const client = new Client(
+			{ name, version: version.toString() },
+			{ capabilities: { tools: {} } },
+		);
+
+		await client.connect(transport);
+		return createResultOk(client);
+	} catch (error) {
+		return createResultError({ type: 'connection', error });
+	}
+}
+
+export async function getAuthHeaders(
+	ctx: Pick<IExecuteFunctions, 'getCredentials'>,
+	authentication: McpAuthenticationOption,
+): Promise<{ headers?: Record<string, string> }> {
+	switch (authentication) {
+		case 'headerAuth': {
+			const header = await ctx
+				.getCredentials<{ name: string; value: string }>('httpHeaderAuth')
+				.catch(() => null);
+
+			if (!header) return {};
+
+			return { headers: { [header.name]: header.value } };
+		}
+		case 'bearerAuth': {
+			const result = await ctx
+				.getCredentials<{ token: string }>('httpBearerAuth')
+				.catch(() => null);
+
+			if (!result) return {};
+
+			return { headers: { Authorization: `Bearer ${result.token}` } };
+		}
+		case 'none':
+		default: {
+			return {};
+		}
+	}
+}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,0 +1,4 @@
+export * from './client';
+export * from './types';
+export * from './FlushingTransport';
+export * from './McpServer';

--- a/mcp/src/types.ts
+++ b/mcp/src/types.ts
@@ -1,0 +1,7 @@
+import type { JSONSchema7 } from 'json-schema';
+
+export type McpTool = { name: string; description?: string; inputSchema: JSONSchema7 };
+
+export type McpToolIncludeMode = 'all' | 'selected' | 'except';
+
+export type McpAuthenticationOption = 'none' | 'headerAuth' | 'bearerAuth';

--- a/mcp/tsconfig.build.json
+++ b/mcp/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": ["./tsconfig.json", "@n8n/typescript-config/tsconfig.build.json"],
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/build.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": [
+    "@n8n/typescript-config/tsconfig.common.json",
+    "@n8n/typescript-config/tsconfig.backend.json"
+  ],
+  "compilerOptions": {
+    "baseUrl": "src",
+    "tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/mcp/tsup.config.ts
+++ b/mcp/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/**/*.ts', '!**/*.test.ts', '!**/*.d.ts'],
+  format: ['cjs'],
+  clean: true,
+  dts: true,
+  bundle: false,
+  sourcemap: true,
+  silent: true,
+});

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
   - packages/extensions/**
   - cypress
   - packages/testing/**
+  - mcp
 
 catalog:
   '@n8n/typeorm': 0.3.20-12


### PR DESCRIPTION
## Summary
- create `@n8n/mcp` package for MCP tooling
- configure workspace to build the new package
- keep existing MCP node code untouched by duplicating helpers into `mcp`

## Testing
- `npx biome check packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.test.ts packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/loadOptions.ts packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/types.ts packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/FlushingTransport.ts packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpServer.ts packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/FlushingTransport.test.ts packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpServer.test.ts packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpTrigger.node.test.ts` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_b_686523871474832daccef97a46cf52a8