### PR TITLE
Allow custom MCP arguments

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
@@ -103,13 +103,13 @@ export function mcpToolToDynamicTool(
 	const rawSchema = convertJsonSchemaToZod(tool.inputSchema);
 
 	// Ensure we always have an object schema for structured tools
-	const objectSchema =
-		rawSchema instanceof z.ZodObject ? rawSchema : z.object({ value: rawSchema });
+       const objectSchema =
+               rawSchema instanceof z.ZodObject ? rawSchema : z.object({ value: rawSchema });
 
 	return new DynamicStructuredTool({
 		name: tool.name,
 		description: tool.description ?? '',
-		schema: objectSchema,
+               schema: objectSchema.passthrough(),
 		func: onCallTool,
 		metadata: { isFromToolkit: true },
 	});

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__test__/McpTrigger.node.test.ts
@@ -76,9 +76,12 @@ describe('McpTrigger Node', () => {
 			const result = await mcpTrigger.webhook(mockContext);
 
 			// Verify that handlePostMessage was called with request, response and tools
-			expect(mockServerManager.handlePostMessage).toHaveBeenCalledWith(mockRequest, mockResponse, [
-				mockTool,
-			]);
+                       expect(mockServerManager.handlePostMessage).toHaveBeenCalledWith(
+                               mockRequest,
+                               mockResponse,
+                               [mockTool],
+                               {},
+                       );
 
 			// Verify the returned result when a tool was called
 			expect(result).toEqual({


### PR DESCRIPTION
## Summary
- allow MCP server to permit unknown tool parameters
- merge custom and query params when calling tools
- expose new parameters on the MCP trigger node
- let MCP client tools forward unknown arguments
- test custom argument handling

## Testing
- `pnpm test` *(fails: Request was cancelled – registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_b_686aa22cae04832d82272bf29047ef0b